### PR TITLE
Specify serenity features, import chrono::Utc only

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 dotenv = "0.15.0"
 log = "0.4.11"
 env_logger = "0.8.2"
-serenity = "0.9"
+serenity = { version = "0.9", default-features = false, features = ["http", "model", "rustls_backend"] }
 tokio = { version = "0.2", features = ["macros"] }
 chrono = "0.4"
 anyhow = "1.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use chrono::{prelude::*, Duration};
+use chrono::{Duration, Utc};
 use dotenv::dotenv;
 use futures::stream::{FuturesUnordered, StreamExt};
 use log::{error, info};


### PR DESCRIPTION
Doesn't reduce binary size but ¯\\_(ツ)_/¯ 