### PR TITLE
Fid Docker image, also build on branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,20 @@ jobs:
           command: build
       - name: Make sure Cargo.lock is up to date
         run: git diff --exit-code Cargo.lock
+  container:
+    name: Build docker container
+    runs-on: ubuntu-latest
+    if: github.ref != 'refs/heads/main' && !startsWith(github.ref, 'refs/tags') # Run only branches (tags and main will build and publish)
+    needs:
+      - clippy_check
+      - test
+      - integration
+      - build
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Build docker container
+        run: docker build -t docker.pkg.github.com/bahlo/discord-retention-bot/discord-retention-bot:branch .
   build_publish:
     name: Build and publish docker container
     runs-on: ubuntu-latest

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM rust:alpine AS builder
 WORKDIR /app
 RUN apk add --no-cache libc-dev
 COPY . /app
-RUN cargo build --release
+RUN rustup override set nightly && \
+    cargo build --release
 
 FROM alpine
 COPY --from=builder /app/target/release/discord-retention-bot /usr/local/bin/discord-retention-bot


### PR DESCRIPTION
We need to make sure the Docker container is still building before merging. This also changes the Rust version to nightly on the Docker image.